### PR TITLE
Compatibility with redis 3.2.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,6 @@ group :development do
   gem "bundler", ">= 1.5.0"
   gem "jeweler", "~> 1.8.4"
   gem "pry"
+  gem "test-unit"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (~> 1.2)
+    power_assert (0.3.0)
     pry (0.9.11.3)
       coderay (~> 1.0.5)
       method_source (~> 0.8)
@@ -76,6 +77,8 @@ GEM
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
     slop (3.4.3)
+    test-unit (3.2.0)
+      power_assert
     tilt (1.4.1)
     vegas (0.1.11)
       rack (>= 1.0.0)
@@ -91,3 +94,7 @@ DEPENDENCIES
   rdoc (~> 3.12)
   resque (~> 1.25.0)
   shoulda
+  test-unit
+
+BUNDLED WITH
+   1.11.2

--- a/lib/resque/uniqueue.rb
+++ b/lib/resque/uniqueue.rb
@@ -56,7 +56,9 @@ module Resque
         local results = {}
         results[1] = redis.call('lpop', queue_name)
         results[2] = redis.call('lpop', start_at_name)
-        redis.call('srem', uniqueue_name, results[1])
+        if results[1] then
+          redis.call('srem', uniqueue_name, results[1])
+        end
         return results
       LUA
     end


### PR DESCRIPTION
Redis 3.2, returns the following error on pop:

ERR Error running script (call to f_8e6ed82be8f07f12e218eb6aa78b5736352ba035): @user_script:7: @user_script: 7: Lua redis() command arguments must be strings or integers
